### PR TITLE
Fixed link issue, improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-G=gcc
-CC=g++
-CFLAGS=-c -Wall
+CFLAGS=-Wall
 LDFLAGS=
 SOURCES=OptionParser.cpp PlayField.cpp main.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
@@ -9,19 +7,19 @@ EXECUTABLE=redbot
 all: $(SOURCES) $(EXECUTABLE) gui
 	
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(LDFLAGS) $(OBJECTS) -pthread -o $@
+	$(CXX) $(LDFLAGS) $(OBJECTS) -pthread -o $@
 
 OptionParser.o: OptionParser.cpp
-	$(CC) $(CFLAGS) -c OptionParser.cpp
+	$(CXX) $(CFLAGS) -c OptionParser.cpp
 
 PlayField.o: PlayField.cpp
-	$(CC) $(CFLAGS) -c PlayField.cpp
+	$(CXX) $(CFLAGS) -c PlayField.cpp
 
 main.o: main.cpp
-	$(CC) $(CFLAGS) -c main.cpp -pthread
+	$(CXX) $(CFLAGS) -c main.cpp -pthread
 
 gui: gui.c
-	$(G) `pkg-config --cflags --libs gtk+-2.0` -o $@ gui.c
+	$(CC) `pkg-config --cflags gtk+-2.0` -o $@ gui.c `pkg-config --libs gtk+-2.0`
 
 clean:
 	rm -rf $(OBJECTS) $(EXECUTABLE) gui


### PR DESCRIPTION
Fixnuty problem s linkovanim s najnovsim gcc na ubuntu 12.04. Link flagy maju ist vzdy na koniec. Dalej CC = compiler C a CXX = compiler C++ nikdy sa nedefinuju explicitne, pochadzaju z prostredia aby si uzivatel mohol pouzit vlastny compiler ako ja napr. clang.

Build s clangom (toto som nefixol nakolko som sa nesprtal v kode):

```
clang++ -Wall -c OptionParser.cpp
clang++ -Wall -c PlayField.cpp
clang++ -Wall -c main.cpp -pthread
clang++  OptionParser.o PlayField.o main.o -pthread -o redbot
clang `pkg-config --cflags gtk+-2.0` -o gui gui.c `pkg-config --libs gtk+-2.0`
gui.c:63:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
gui.c:363:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
2 warnings generated.
```
